### PR TITLE
Removed smooth scrolling, for better scrolling in OSX.

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,7 +361,6 @@
     <script type="text/javascript" src="assets/plugins/jquery/jquery-migrate.min.js"></script>    
     <script type="text/javascript" src="assets/plugins/bootstrap/js/bootstrap.min.js"></script>
     <!-- JS Implementing Plugins -->
-    <script type="text/javascript" src="assets/plugins/smoothScroll.js"></script>    
     <script type="text/javascript" src="assets/plugins/jquery.easing.min.js"></script>
     <!-- JS Page Level-->
     <script type="text/javascript" src="assets/js/one.app.js"></script>


### PR DESCRIPTION
Scrolling in OSX and most mobile platforms is already smooth. The smooth scrolling plugin causes scroll smoothness and speed to increase dramatically. Essentially scrolling becomes a binary operation in OSX with your choice of top or bottom :)