### PR TITLE
Add scrollable space on main window

### DIFF
--- a/ImagePlay/include/IPProcessGrid.h
+++ b/ImagePlay/include/IPProcessGrid.h
@@ -76,6 +76,8 @@ public slots:
     void                    updateProgress          (int);
 
 private:
+    void                    fitLargeSceneRect();
+
     IPProcessGridScene*     _scene;                 //!< Scene
     float                   _scale;                 //!< Scale for zooming
     MainWindow*             _mainWindow;            //!< MainWindow

--- a/ImagePlay/include/IPProcessGrid.h
+++ b/ImagePlay/include/IPProcessGrid.h
@@ -94,10 +94,10 @@ private:
     // QWidget interface
 protected:
     void                    wheelEvent              (QWheelEvent *);
-    void                    showEvent               (QShowEvent *);
-    void                    resizeEvent             (QResizeEvent *);
+    virtual void            resizeEvent             (QResizeEvent *)                        override;
     void                    keyPressEvent           (QKeyEvent *);
     void                    keyReleaseEvent         (QKeyEvent *);
+    virtual void            showEvent               (QShowEvent *)                          override;
 };
 
 #endif // IPPROCESSGRID_H

--- a/ImagePlay/src/IPProcessGrid.cpp
+++ b/ImagePlay/src/IPProcessGrid.cpp
@@ -471,7 +471,7 @@ void IPProcessGrid::showEvent(QShowEvent *e)
 {
     //set the scene rect to allow more space when zooming
     if ( !e->spontaneous() ){
-       setSceneRect(0,0,width()*2,height()*2);
+       fitLargeSceneRect();
     }
 }
 
@@ -480,7 +480,22 @@ void IPProcessGrid::showEvent(QShowEvent *e)
  */
 void IPProcessGrid::resizeEvent(QResizeEvent *)
 {
-   setSceneRect(0,0,width()*2,height()*2);
+   fitLargeSceneRect();
+}
+
+/*!
+ * \brief IPProcessGrid::fitLargeSceneRect
+ */
+void IPProcessGrid::fitLargeSceneRect()
+{
+    qreal width = this->width()*2;
+    qreal height = this->height()*2;
+    if ( scene()->sceneRect().width() > width )
+        width = scene()->sceneRect().width();
+    if ( scene()->sceneRect().height() > height )
+        height = scene()->sceneRect().height();
+
+    setSceneRect(0,0,width,height);
 }
 
 /*!

--- a/ImagePlay/src/IPProcessGrid.cpp
+++ b/ImagePlay/src/IPProcessGrid.cpp
@@ -467,11 +467,12 @@ void IPProcessGrid::wheelEvent(QWheelEvent* event)
 /*!
  * \brief IPProcessGrid::showEvent
  */
-void IPProcessGrid::showEvent(QShowEvent *)
+void IPProcessGrid::showEvent(QShowEvent *e)
 {
-    // add a big object to make sure the coordinate system starts top left
-    //QPen invisiblePen(QColor(0,0,0));
-    //_scene->addRect(0,0,width()-5,height()-5,invisiblePen);
+    //set the scene rect to allow more space when zooming
+    if ( !e->spontaneous() ){
+       setSceneRect(0,0,width()*2,height()*2);
+    }
 }
 
 /*!
@@ -479,6 +480,7 @@ void IPProcessGrid::showEvent(QShowEvent *)
  */
 void IPProcessGrid::resizeEvent(QResizeEvent *)
 {
+   setSceneRect(0,0,width()*2,height()*2);
 }
 
 /*!


### PR DESCRIPTION
possible fix for #4 by forcing a large sceneRect() (this sets the scrollable bounds of
the graphics view, otherwise the max extents of the scene are used)