### PR TITLE
Added missing library ldl to linking flags

### DIFF
--- a/ImagePlay/ImagePlay.pro
+++ b/ImagePlay/ImagePlay.pro
@@ -130,6 +130,7 @@ linux: {
     LIBS += -lopencv_core
     LIBS += -lopencv_imgproc
     LIBS += -lopencv_highgui
+    LIBS += -ldl
 
     QMAKE_POST_LINK +=  $${QMAKE_COPY_DIR} media/process_icons/ ../_bin/$$CONFIGURATION/$$PLATFORM/ && \
                         $${QMAKE_COPY_DIR} media/examples/ ../_bin/$$CONFIGURATION/$$PLATFORM/ &&\


### PR DESCRIPTION
Without this flag, I get following error:

    /sbin/ld: ../intermediate/ImagePlay/Release/linux/IPPluginManager.o: undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
    /usr/lib/libdl.so.2: error adding symbols: DSO missing from command line


I'm using ArchLinux with GCC 5.3.0 and glibc 2.22.