### PR TITLE
Create AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+dist: trusty
 language: cpp
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ before_install:
 
 script:
  - qmake -recursive QMAKE_CXX=g++-4.8 QMAKE_CC=gcc-4.8
- - make
+ - make PREFIX=/app
+ - sudo make install
+ - find /app
  
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
  - qmake -recursive QMAKE_CXX=g++-4.8 QMAKE_CC=gcc-4.8  PREFIX=/app
  - make
  - sudo make install
+ - cd ../
  - find /app
  - curl --upload-file /app/bin/imageplay https://transfer.sh/imageplay
  - bash -ex appimage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
  - make
  - sudo make install
  - find /app
- - curl --upload-file ./app/bin/imageplay https://transfer.sh/imageplay
+ - curl --upload-file /app/bin/imageplay https://transfer.sh/imageplay
  - bash -ex appimage.sh
  
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ script:
  - make
  - sudo make install
  - find /app
+ - curl --upload-file ./app/bin/imageplay https://transfer.sh/imageplay
+ - bash -ex appimage.sh
  
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_install:
  - sudo apt-get -y install libfreeimage-dev libopencv-core-dev libopencv-core-dev libopencv-imgproc-dev libopencv-highgui-dev
 
 script:
- - qmake -recursive QMAKE_CXX=g++-4.8 QMAKE_CC=gcc-4.8
- - make PREFIX=/app
+ - qmake -recursive QMAKE_CXX=g++-4.8 QMAKE_CC=gcc-4.8  PREFIX=/app
+ - make
  - sudo make install
  - find /app
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
  - qmake -recursive QMAKE_CXX=g++-4.8 QMAKE_CC=gcc-4.8  PREFIX=/app
  - make
  - sudo make install
- - cd ../
  - find /app
  - curl --upload-file /app/bin/imageplay https://transfer.sh/imageplay
  - bash -ex appimage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ before_install:
  # g++ 4.8 for std=c++11
  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
  # additional headerfiles
- - sudo apt-get install libXxf86vm-dev libXi-dev libudev-dev libXcursor-dev
- - sudo apt-get install -f qtbase5-dev qt5-default qttools5-dev-tools libqt5opengl5-dev
- - sudo apt-get install libfreeimage-dev libopencv-core-dev libopencv-core-dev libopencv-imgproc-dev libopencv-highgui-dev
+ - sudo apt-get -y install libXxf86vm-dev libXi-dev libudev-dev libXcursor-dev
+ - sudo apt-get -y install -f qtbase5-dev qt5-default qttools5-dev-tools libqt5opengl5-dev
+ - sudo apt-get -y install libfreeimage-dev libopencv-core-dev libopencv-core-dev libopencv-imgproc-dev libopencv-highgui-dev
 
 script:
  - qmake -recursive QMAKE_CXX=g++-4.8 QMAKE_CC=gcc-4.8

--- a/appimage.sh
+++ b/appimage.sh
@@ -26,7 +26,7 @@ cd $APP.AppDir
 sudo chown -R $USER /app/
 sed -i -e 's|/app/|././|g' /app/usr/bin/imageplay
 
-cp /app/usr/bin/imageplay ./usr/bin/
+cp /app/bin/imageplay ./usr/bin/
 
 ########################################################################
 # Copy desktop and icon file to AppDir for AppRun to pick them up

--- a/appimage.sh
+++ b/appimage.sh
@@ -24,7 +24,7 @@ wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./func
 cd $APP.AppDir
 
 sudo chown -R $USER /app/
-sed -i -e 's|/app/|././|g' /app/bin/imageplay
+sed -i -e 's|/app|././|g' /app/bin/imageplay
 
 cp /app/bin/imageplay ./usr/bin/
 

--- a/appimage.sh
+++ b/appimage.sh
@@ -13,7 +13,8 @@ LOWERAPP=${APP,,}
 
 GIT_REV=$(git rev-parse --short HEAD)
 echo $GIT_REV
-make install DESTDIR=/home/travis/$APP/$APP.AppDir
+
+mkdir -p $HOME/$APP/$APP.AppDir/usr/bin/
 
 cd $HOME/$APP/
 
@@ -21,6 +22,11 @@ wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./func
 . ./functions.sh
 
 cd $APP.AppDir
+
+sudo chown -R $USER /app/
+sed -i -e 's|/app/|././|g' /app/usr/bin/imageplay
+
+cp /app/usr/bin/imageplay ./usr/bin/
 
 ########################################################################
 # Copy desktop and icon file to AppDir for AppRun to pick them up

--- a/appimage.sh
+++ b/appimage.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+########################################################################
+# Package the binaries built on Travis-CI as an AppImage
+# By Simon Peter 2016
+# For more information, see http://appimage.org/
+########################################################################
+
+export ARCH=$(arch)
+
+APP=ImagePlay
+LOWERAPP=${APP,,}
+
+GIT_REV=$(git rev-parse --short HEAD)
+echo $GIT_REV
+make install DESTDIR=/home/travis/$APP/$APP.AppDir
+
+cd $HOME/$APP/
+
+wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
+. ./functions.sh
+
+cd $APP.AppDir
+
+########################################################################
+# Copy desktop and icon file to AppDir for AppRun to pick them up
+########################################################################
+
+get_apprun
+
+# FIXME: Use the official .desktop file - where is it?
+cat > $LOWERAPP.desktop <<EOF
+[Desktop Entry]
+Name=$APP
+Icon=$LOWERAPP
+Type=Application
+Comment=$APP
+Categories=Graphics;
+Exec=$LOWERAPP
+EOF
+
+cp "../res/ImagePlay.png" $LOWERAPP.png
+
+########################################################################
+# Copy in the dependencies that cannot be assumed to be available
+# on all target systems
+########################################################################
+
+# FIXME: How to find out which subset of plugins is really needed?
+mkdir -p ./usr/lib/qt5/plugins/
+PLUGINS=/usr/lib/x86_64-linux-gnu/qt5/plugins/
+cp -r $PLUGINS/* ./usr/lib/qt5/plugins/
+
+copy_deps
+
+# Move the libraries to usr/bin
+move_lib
+mv usr/lib/x86_64-linux-gnu/* usr/lib/
+
+########################################################################
+# Delete stuff that should not go into the AppImage
+########################################################################
+
+# Delete dangerous libraries; see
+# https://github.com/probonopd/AppImages/blob/master/excludelist
+delete_blacklisted
+
+# We don't bundle the developer stuff
+rm -rf usr/include || true
+rm -rf usr/lib/cmake || true
+rm -rf usr/lib/pkgconfig || true
+find . -name '*.la' | xargs -i rm {}
+strip usr/bin/* usr/lib/* || true
+
+########################################################################
+# desktopintegration asks the user on first run to install a menu item
+########################################################################
+
+get_desktopintegration $LOWERAPP
+
+########################################################################
+# Determine the version of the app; also include needed glibc version
+########################################################################
+
+GLIBC_NEEDED=$(glibc_needed)
+VERSION=git$GIT_REV-glibc$GLIBC_NEEDED
+
+########################################################################
+# Patch away absolute paths; it would be nice if they were relative
+########################################################################
+
+pach_usr
+# Possibly need to patch additional hardcoded paths away, replace
+# "/usr" with "././" which means "usr/ in the AppDir"
+
+########################################################################
+# AppDir complete
+# Now packaging it as an AppImage
+########################################################################
+
+cd .. # Go out of AppImage
+
+mkdir -p ../out/
+generate_appimage
+
+########################################################################
+# Upload the AppDir
+########################################################################
+
+transfer ../out/*

--- a/appimage.sh
+++ b/appimage.sh
@@ -45,7 +45,7 @@ Categories=Graphics;
 Exec=$LOWERAPP
 EOF
 
-ls ../../
+find ../../ -name ImagePlay.png
 cp ../../ImagePlay/res/ImagePlay.png $LOWERAPP.png
 
 ########################################################################

--- a/appimage.sh
+++ b/appimage.sh
@@ -45,7 +45,8 @@ Categories=Graphics;
 Exec=$LOWERAPP
 EOF
 
-cp "../res/ImagePlay.png" $LOWERAPP.png
+ls ../../
+cp ../../ImagePlay/res/ImagePlay.png $LOWERAPP.png
 
 ########################################################################
 # Copy in the dependencies that cannot be assumed to be available

--- a/appimage.sh
+++ b/appimage.sh
@@ -95,7 +95,7 @@ VERSION=git$GIT_REV-glibc$GLIBC_NEEDED
 # Patch away absolute paths; it would be nice if they were relative
 ########################################################################
 
-pach_usr
+patch_usr
 # Possibly need to patch additional hardcoded paths away, replace
 # "/usr" with "././" which means "usr/ in the AppDir"
 

--- a/appimage.sh
+++ b/appimage.sh
@@ -45,8 +45,7 @@ Categories=Graphics;
 Exec=$LOWERAPP
 EOF
 
-find ../../ -name ImagePlay.png
-cp ../../ImagePlay/res/ImagePlay.png $LOWERAPP.png
+find ../../ -name ImagePlay.png -exec cp {} imageplay.png \;
 
 ########################################################################
 # Copy in the dependencies that cannot be assumed to be available

--- a/appimage.sh
+++ b/appimage.sh
@@ -24,7 +24,7 @@ wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./func
 cd $APP.AppDir
 
 sudo chown -R $USER /app/
-sed -i -e 's|/app/|././|g' /app/usr/bin/imageplay
+sed -i -e 's|/app/|././|g' /app/bin/imageplay
 
 cp /app/bin/imageplay ./usr/bin/
 


### PR DESCRIPTION
When merged, this PR will create an [AppImage](http://appimage.org/) for every commit.

Toward the end of the build log, you will see a transfer.sh where the AppImage has been uploaded to. It will be stored there for 2 weeks. You could upload to gh-releases instead.

Successfully tested (=known to launch on)
- CentOS-7.0-1406-x86_64-GnomeLive.iso
- CentOS-7-x86_64-LiveGNOME-1511.iso
- Chromixium-1.5-amd64.iso
- debian-live-8.0.0-amd64-xfce-desktop+nonfree.iso
- debian-live-8.4.0-amd64-gnome-desktop.iso
- elementary_OS_0.3_freya_amd64.iso
- Fedora-Live-Workstation-x86_64-22-3.iso
- Fedora-Live-Workstation-x86_64-23-10.iso
- kali-linux-2016.1-amd64.iso
- kali-linux-2.0-amd64.iso
- kubuntu-14.04.4-desktop-amd64.iso
- kubuntu-15.04-desktop-amd64.iso
- kubuntu-16.04-desktop-amd64.iso
- SL-72-x86_64-2016-02-03-LiveDVDgnome.iso
- ubuntu-14.04.1-desktop-amd64.iso
- ubuntu-16.04-desktop-amd64.iso
- ubuntu-gnome-16.04-desktop-amd64.iso
- ubuntu-mate-16.04-desktop-amd64.iso
- xenial-desktop-amd64.iso
- xubuntu-16.04-desktop-amd64.iso

Please [squash](https://help.github.com/articles/about-pull-request-merge-squashing/) the commits when merging.
