### PR TITLE
input: desktop screenshot/screencast as an input (#103)

### DIFF
--- a/IPL/IPL.pro
+++ b/IPL/IPL.pro
@@ -17,7 +17,8 @@
 #
 ##############################################################################
 
-CONFIG -= qt
+# CONFIG -= qt
+QT       += core gui
 
 TARGET = IPL
 CONFIG(debug, debug|release): DESTDIR  = ../ImagePlay/debug

--- a/IPL/include/IPL_processes.h
+++ b/IPL/include/IPL_processes.h
@@ -27,6 +27,7 @@
 //#include "IPLLoadVideo.h"
 #include "IPLCamera.h"
 #include "IPLLoadImageSequence.h"
+#include "IPLScreenshot.h"
 #include "IPLSynthesize.h"
 #include "IPLSaveImage.h"
 #include "IPLBinarize.h"

--- a/IPL/include/processes/IPLScreenshot.h
+++ b/IPL/include/processes/IPLScreenshot.h
@@ -1,0 +1,61 @@
+//#############################################################################
+//
+//  This file is part of ImagePlay.
+//
+//  ImagePlay is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ImagePlay is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with ImagePlay.  If not, see <http://www.gnu.org/licenses/>.
+//
+//#############################################################################
+
+#ifndef IPLSCREENSHOT_H
+#define IPLSCREENSHOT_H
+
+#include <string>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QPixmap>
+#include <QImage>
+
+#include "IPL_global.h"
+#include "IPLProcess.h"
+
+#include "opencv2/core/core.hpp"
+#include "opencv2/imgproc/imgproc.hpp"
+#include "opencv2/highgui/highgui.hpp"
+
+/**
+ * @brief The IPLScreenshot class
+ */
+class IPLSHARED_EXPORT IPLScreenshot : public IPLClonableProcess<IPLScreenshot>
+{
+ public:
+    IPLScreenshot() : IPLClonableProcess() { init(); }
+    ~IPLScreenshot()  { destroy(); }
+
+    void init();
+    void destroy();
+    virtual bool        processInputData            (IPLData* data, int inNr, bool useOpenCV);
+    virtual IPLImage*   getResultData               (int outNr);
+    virtual void        afterProcessing             ();
+
+ protected:
+    IPLImage*           _result;
+    bool                _continuous;
+
+    int                 _winId;
+    QPixmap             _pixmap;
+    QImage              _qimage;
+    cv::Mat             _mat;
+};
+
+#endif // IPLSCREENSHOT_H

--- a/IPL/src/processes/IPLScreenshot.cpp
+++ b/IPL/src/processes/IPLScreenshot.cpp
@@ -1,0 +1,94 @@
+//#############################################################################
+//
+//  This file is part of ImagePlay.
+//
+//  ImagePlay is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ImagePlay is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with ImagePlay.  If not, see <http://www.gnu.org/licenses/>.
+//
+//#############################################################################
+
+#include "IPLScreenshot.h"
+
+void IPLScreenshot::init()
+{
+    // init
+    _result         = NULL;
+    _winId          = 0;
+
+    // basic settings
+    setClassName("IPLScreenshot");
+    setTitle("Load from another running window/desktop");
+    setCategory(IPLProcess::CATEGORY_IO);
+    setIsSource(true);
+
+    // inputs and outputs
+    addOutput("Image", IPL_IMAGE_COLOR);
+
+    addProcessPropertyUnsignedInt("trigger", "Trigger Image", "", 0, IPL_WIDGET_BUTTON);
+    addProcessPropertyBool("continuous", "Run continuously", "", false, IPL_WIDGET_CHECKBOXES);
+    // addProcessPropertyInt("wid", "Window Selector", "", ...);
+}
+
+void IPLScreenshot::destroy()
+{
+    delete _result;
+}
+
+bool IPLScreenshot::processInputData(IPLData*, int, bool)
+{
+    // delete previous result
+    delete _result;
+    _result = NULL;
+    _continuous = getProcessPropertyBool("continuous");
+
+    notifyProgressEventHandler(-1);
+
+    // if (const QWindow *window = windowHandle())
+    // screen = window->screen();
+    QScreen *screen = QGuiApplication::primaryScreen();
+    // QDesktopWidget* dw = QApplication::desktop();
+    if (!screen)
+        return NULL;
+    _pixmap = screen->grabWindow(0);
+
+    _qimage = _pixmap.toImage();
+    _mat = cv::Mat(_qimage.height(), _qimage.width(), CV_8UC4, (uchar*)_qimage.bits(), _qimage.bytesPerLine());
+    _result = new IPLImage(_mat);
+
+    if(!_result)
+    {
+        addError("Could not fetch screenshot.");
+        return false;
+    }
+
+    /*
+    std::stringstream s;
+    s << "Foo ";
+    addInformation(s.str());
+    */
+
+    return true;
+}
+
+IPLImage *IPLScreenshot::getResultData(int)
+{
+    return _result;
+}
+
+void IPLScreenshot::afterProcessing()
+{
+    if(_continuous)
+    {
+        notifyPropertyChangedEventHandler();
+    }
+}

--- a/ImagePlay/src/MainWindow.cpp
+++ b/ImagePlay/src/MainWindow.cpp
@@ -456,6 +456,7 @@ void MainWindow::loadProcesses()
     _factory->registerProcess("IPLCamera",              new IPLCamera);
     //_factory->registerProcess("IPLLoadVideo",           new IPLLoadVideo);
     _factory->registerProcess("IPLLoadImageSequence",   new IPLLoadImageSequence);
+    _factory->registerProcess("IPLScreenshot",          new IPLScreenshot);
     _factory->registerProcess("IPLSaveImage",           new IPLSaveImage);
     _factory->registerProcess("IPLSplitPlanes",         new IPLSplitPlanes);
     _factory->registerProcess("IPLMergePlanes",         new IPLMergePlanes);


### PR DESCRIPTION
Attempt to fix #103
I believe the hunk on `IPL/IPL.pro` that make IPL library link with qt would not be appreciated.
I didn't know the code enough to find another solution, but wanted to offer this one anyway. I hope you could find an architectural tweak to make this possible.
[I've yet to find a consistent way to select a virtual desktop and/or a screen].
