### PR TITLE
ability to set VideoCapture using a specific device id

### DIFF
--- a/IPL/include/IPLCameraIO.h
+++ b/IPL/include/IPLCameraIO.h
@@ -33,11 +33,12 @@
 class IPLSHARED_EXPORT IPLCameraIO
 {
 public:
-    static IPLImage*            grabFrame(bool forcedCapture = false);
+    static IPLImage*            grabFrame(uint camera_id, bool forcedCapture = false);
     static cv::VideoCapture*    camera();
     static void                 release();
 private:
     static cv::VideoCapture*    _camera;
+    static uint                 _last_camera_id;
     static IPLImage*            _lastFrame;
 };
 

--- a/IPL/include/processes/IPLCamera.h
+++ b/IPL/include/processes/IPLCamera.h
@@ -46,6 +46,7 @@ public:
 protected:
     IPLImage*               _result;
     bool                    _continuous;
+    uint                    _camera_id;
 };
 
 #endif // IPLCAMERA_H

--- a/IPL/src/IPLCameraIO.cpp
+++ b/IPL/src/IPLCameraIO.cpp
@@ -20,14 +20,17 @@
 #include "IPLCameraIO.h"
 
 cv::VideoCapture*   IPLCameraIO::_camera    = NULL;
+uint                IPLCameraIO::_last_camera_id = 0;
 IPLImage*           IPLCameraIO::_lastFrame = NULL;
 
-IPLImage* IPLCameraIO::grabFrame(bool forcedCapture/* = false*/)
+IPLImage* IPLCameraIO::grabFrame(uint camera_id, bool forcedCapture/* = false*/)
 {
     // connect camera once
-    if(!_camera)
+    if(!_camera || _last_camera_id != camera_id)
     {
-        _camera = new cv::VideoCapture(0);
+	release();
+        _camera = new cv::VideoCapture(camera_id);
+	_last_camera_id = camera_id;
     }
 
     if(!_camera->isOpened())

--- a/IPL/src/processes/IPLCamera.cpp
+++ b/IPL/src/processes/IPLCamera.cpp
@@ -38,6 +38,7 @@ void IPLCamera::init()
 
     addProcessPropertyUnsignedInt("trigger", "Trigger Image", "", 0, IPL_WIDGET_BUTTON);
     addProcessPropertyBool("continuous", "Run continuously", "", false, IPL_WIDGET_CHECKBOXES);
+    addProcessPropertyInt("camera_id", "Camera ID", "", 0, IPL_WIDGET_SLIDER, 0, 5);
 
     // all properties which can later be changed by gui
     addProcessPropertyInt("width", "Width", "", 640, IPL_WIDGET_SLIDER, 640, 1920);
@@ -62,6 +63,7 @@ bool IPLCamera::processInputData(IPLData*, int, bool)
     _result = NULL;
 
     _continuous = getProcessPropertyBool("continuous");
+    _camera_id = getProcessPropertyInt("camera_id");
 
     /*if (_continuous = getProcessPropertyBool("continuous"))
     {
@@ -92,7 +94,7 @@ bool IPLCamera::processInputData(IPLData*, int, bool)
     //delete _camera;
     //_camera = NULL;
 
-    _result = IPLCameraIO::grabFrame(!_continuous);
+    _result = IPLCameraIO::grabFrame((uint)_camera_id, !_continuous);
 
     // if we didn't get a frame
     if(!_result)


### PR DESCRIPTION
Much need configuration when using an external camera on a laptop embedding a default one.

_Note that while this theorically allows creating multiple continuous VideoCapture processes, such a thing is barely unusable ATM._
