### PR TITLE
warns when an invalid/absent image extension is set for SaveImage

### DIFF
--- a/IPL/src/processes/IPLSaveImage.cpp
+++ b/IPL/src/processes/IPLSaveImage.cpp
@@ -138,6 +138,11 @@ bool IPLSaveImage::processInputData(IPLData* data, int, bool)
         else
             flags = PNM_SAVE_ASCII;
     }
+    else {
+        addError("Unknown image extension for saving");
+        delete _result;
+        return false;
+    }
 
     notifyProgressEventHandler(-1);
 


### PR DESCRIPTION
... instead of creating an empty file.